### PR TITLE
:green_heart: Drop EOL Python 3.7 from the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - '3.7.x'
         - '3.8.x'
         - '3.9.x'
         - '3.10.x'


### PR DESCRIPTION
Python 3.7 (EOL 2023-06) is no longer provided by setup-python on the updated runners (ubuntu-24.04, macOS arm64), which is the only failing combination in the matrix. Remove it to restore a green build.