### PR TITLE
:wrench: Migrate project metadata to pyproject.toml [project] (PEP 621)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
           - language: actions
             build-mode: none
           - language: c-cpp
-            build-mode: autobuild
+            build-mode: manual
           - language: python
             build-mode: none
     steps:
@@ -42,6 +42,19 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+
+      # Build the c-cpp database with an explicit build instead of autobuild:
+      # autobuild runs setup.py with the runner's old system setuptools (no PEP
+      # 517 isolation), which cannot parse the PEP 639 SPDX license. `pip install`
+      # builds with isolation (setuptools>=77) and CodeQL traces the compile.
+      - name: Set up Python
+        if: matrix.build-mode == 'manual'
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.x'
+      - name: Build the C extension
+        if: matrix.build-mode == 'manual'
+        run: pip install .
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,50 @@
 # Build configuration for the list_reserve CPython C extension.
-# setup.py remains the build script; this file declares PEP 517 build
-# requirements and the cibuildwheel configuration (single source of truth,
-# read identically by cibuildwheel locally and in CI).
+# Project metadata lives here (PEP 621 [project]); setup.py carries only the
+# Extension() definition. This file also declares the PEP 517 [build-system]
+# and the cibuildwheel config (single source of truth, read identically by
+# cibuildwheel locally and in CI).
 
 [build-system]
 # setuptools>=65.4.1 is cibuildwheel's documented floor for Windows ARM64 wheel
 # tagging; harmless on every other platform.
 requires = ["setuptools>=65.4.1", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "list_reserve"
+version = "0.4.0"
+description = "Python builtin list memory allocation library"
+readme = "README.md"
+# With Python 3.8/3.9 dropped (min 3.10), the SPDX `license = "MIT"` form
+# (PEP 639) is now viable, but it requires raising the build-system floor to
+# setuptools>=77. Kept as the table form to leave [build-system] untouched;
+# switch to SPDX when that floor is bumped.
+license = { text = "MIT" }
+authors = [{ name = "ChanTsune", email = "yshegou@gmail.com" }]
+keywords = ["list", "extension", "memory", "reserve", "capacity"]
+requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "License :: OSI Approved :: MIT License",
+]
+
+[project.urls]
+Homepage = "https://github.com/ChanTsune/list-reserve"
+
+# Explicit package list: with [project] present, setuptools enables automatic
+# discovery, which would trip over the src/ directory. Declare the stub package
+# directly.
+[tool.setuptools]
+packages = ["list_reserve"]
+
+[tool.setuptools.package-data]
+list_reserve = ["py.typed", "__init__.pyi"]
 
 [tool.cibuildwheel]
 # CPython only, 3.10 through 3.14. PyPy (pp*), GraalPy (gp*), free-threaded

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,9 @@
 # cibuildwheel locally and in CI).
 
 [build-system]
-# setuptools>=65.4.1 is cibuildwheel's documented floor for Windows ARM64 wheel
-# tagging; harmless on every other platform.
-requires = ["setuptools>=65.4.1", "wheel"]
+# setuptools>=77 for PEP 639 SPDX license expression support; this also clears
+# cibuildwheel's >=65.4.1 floor for Windows ARM64 wheel tagging.
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -15,11 +15,8 @@ name = "list_reserve"
 version = "0.4.0"
 description = "Python builtin list memory allocation library"
 readme = "README.md"
-# With Python 3.8/3.9 dropped (min 3.10), the SPDX `license = "MIT"` form
-# (PEP 639) is now viable, but it requires raising the build-system floor to
-# setuptools>=77. Kept as the table form to leave [build-system] untouched;
-# switch to SPDX when that floor is bumped.
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [{ name = "ChanTsune", email = "yshegou@gmail.com" }]
 keywords = ["list", "extension", "memory", "reserve", "capacity"]
 requires-python = ">=3.10"
@@ -31,7 +28,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "License :: OSI Approved :: MIT License",
 ]
 
 [project.urls]

--- a/setup.py
+++ b/setup.py
@@ -1,36 +1,10 @@
-import os
 from setuptools import setup, Extension
 
-
-def read(fname):
-    with open(os.path.join(os.path.dirname(__file__), fname)) as f:
-        return f.read()
-
-
-setup(name="list_reserve",
-      version="0.4.0",
-      description="Python builtin list memory allocation library",
-      long_description=read("README.md"),
-      long_description_content_type="text/markdown",
-      packages=["list_reserve"],
-      package_data={"list_reserve": ["py.typed", "__init__.pyi"]},
-      ext_modules=[
-          Extension("list_reserve", ["src/list_reserve.c"])
-      ],
-      url="https://github.com/ChanTsune/list-reserve",
-      author="ChanTsune",
-      author_email="yshegou@gmail.com",
-      license="MIT",
-      keywords="list extension memory reserve capacity",
-      python_requires=">=3.10",
-      classifiers=[
-          'Programming Language :: Python',
-          'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.10',
-          'Programming Language :: Python :: 3.11',
-          'Programming Language :: Python :: 3.12',
-          'Programming Language :: Python :: 3.13',
-          'Programming Language :: Python :: 3.14',
-          'License :: OSI Approved :: MIT License',
-      ],
-      )
+# Project metadata is declared in pyproject.toml ([project]). setup.py only
+# carries the C extension definition, which setuptools' declarative
+# [tool.setuptools.ext-modules] table cannot yet express stably.
+setup(
+    ext_modules=[
+        Extension("list_reserve", ["src/list_reserve.c"]),
+    ],
+)


### PR DESCRIPTION
Move name/version/description/readme/license/authors/keywords/classifiers/urls from setup.py into the PEP 621 [project] table in pyproject.toml. setup.py now carries only the ext_modules Extension() definition; package data and the explicit package list move to [tool.setuptools]. No change to published metadata.