### PR TITLE
:bug: Guard list_realloc against allocation size overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Python 3.8 and 3.9 support (end of life).
 
+### Fixed
+- `reserve()` raises `MemoryError` when the requested capacity is too large
+  to allocate.
+
 ## [0.4.0] - 2026-06-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip install list_reserve
 
 ### capacity
 
-Return allocated list memory size.
+Return the number of item slots currently allocated for a list.
 
 ```py
 from list_reserve import capacity
@@ -26,7 +26,7 @@ print(capacity(l)) # 3
 
 ### reserve
 
-Reserve list memory.
+Reserve list capacity.
 
 ```py
 from list_reserve import reserve, capacity
@@ -37,6 +37,17 @@ reserve(l, 10)
 print(len(l)) # 0
 
 print(capacity(l)) # 10
+```
+
+### allocated_bytes
+
+Return the memory size currently allocated for list item slots.
+
+```py
+from list_reserve import allocated_bytes
+
+l = [1, 2, 3]
+print(allocated_bytes(l)) # capacity(l) * pointer size
 ```
 
 ### shrink_to_fit

--- a/src/list_reserve.c
+++ b/src/list_reserve.c
@@ -12,7 +12,12 @@ list_realloc(PyListObject *self, Py_ssize_t newsize) {
         return 0;
     }
 
-    num_allocated_bytes = newsize * sizeof(PyObject *);
+    if (newsize > PY_SSIZE_T_MAX / (Py_ssize_t)sizeof(PyObject *)) {
+        PyErr_NoMemory();
+        return -1;
+    }
+
+    num_allocated_bytes = (size_t)newsize * sizeof(PyObject *);
     items = (PyObject **)PyMem_Realloc(self->ob_item, num_allocated_bytes);
     if (items == NULL) {
         PyErr_NoMemory();
@@ -106,7 +111,7 @@ list_allocated_bytes(PyObject *self, PyObject *args) {
         return NULL;
     }
     PyListObject *list = (PyListObject *)o;
-    Py_ssize_t allocated_bytes = list->allocated * sizeof(PyListObject *);
+    Py_ssize_t allocated_bytes = list->allocated * sizeof(PyObject *);
     PyObject *capacity = PyLong_FromSsize_t(allocated_bytes);
     if (capacity == NULL) {
         return NULL;

--- a/test.py
+++ b/test.py
@@ -20,15 +20,26 @@ class ListReserveTest(TestCase):
 
         lst = [1, 2, 3]
         cases = [
-            ([], 100, 100),  # (list, reserve, excepted)
+            ([], 100, 100),  # (list, reserve, expected)
+            ([1, 2, 3], 100, 100),  # grow a populated list (realloc copies live items)
             ([], 0, 0),
             ([], -1, 0),
             (lst, 1, capacity(lst)),
             (lst, -10, capacity(lst)),
         ]
-        for lst, size, excepted in cases:
+        for lst, size, expected in cases:
+            original = list(lst)
+            original_len = len(lst)
             reserve(lst, size)
-            self.assertEqual(capacity(lst), excepted)
+            self.assertEqual(capacity(lst), expected)
+            self.assertEqual(lst, original)
+            self.assertEqual(len(lst), original_len)
+
+    def test_reserve_too_large_error(self):
+        from list_reserve import reserve
+
+        with self.assertRaises(MemoryError):
+            reserve([], maxsize)
 
     def test_reserve_error(self):
         from list_reserve import reserve
@@ -41,16 +52,24 @@ class ListReserveTest(TestCase):
 
         lst = []
         lst.append(1)
+        original = list(lst)
+        original_len = len(lst)
         shrink_to_fit(lst)
 
         self.assertEqual(capacity(lst), len(lst))
+        self.assertEqual(lst, original)
+        self.assertEqual(len(lst), original_len)
 
     def test_shrink_to_fit_no_action(self):
         from list_reserve import capacity, shrink_to_fit
 
         lst = [1, 2, 3, 4]
+        original = list(lst)
+        original_len = len(lst)
         shrink_to_fit(lst)
         self.assertEqual(capacity(lst), len(lst))
+        self.assertEqual(lst, original)
+        self.assertEqual(len(lst), original_len)
 
     def test_shrink_to_fit_error(self):
         from list_reserve import shrink_to_fit
@@ -65,10 +84,15 @@ class AllocatedBytesTest(TestCase):
         return 8 if maxsize > 2**32 else 4
 
     def test_allocated_bytes(self):
-        from list_reserve import allocated_bytes
+        from list_reserve import allocated_bytes, capacity
 
-        self.assertEqual(allocated_bytes([]), 0 * self._pointer_size)
-        self.assertEqual(allocated_bytes([1]), 1 * self._pointer_size)
+        empty = []
+        one_item = [1]
+
+        self.assertEqual(allocated_bytes(empty), capacity(empty) * self._pointer_size)
+        self.assertEqual(
+            allocated_bytes(one_item), capacity(one_item) * self._pointer_size
+        )
 
     def test_allocated_bytes_error(self):
         from list_reserve import allocated_bytes


### PR DESCRIPTION
- Reject newsize that would overflow size_t before the byte-size multiplication in list_realloc; raise MemoryError instead
- Use sizeof(PyObject *) for allocated_bytes (the actual ob_item slot type) instead of sizeof(PyListObject *)
- Assert reserve/shrink_to_fit leave list contents and length intact, add a populated-list grow case exercising the realloc copy path, and cover the too-large reserve error
- Document allocated_bytes in README