### PR TITLE
:construction_worker: Switch release trigger to ":bookmark: Release X.Y.Z" commits

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -106,7 +106,7 @@ jobs:
     needs: [build_wheels, make_sdist]
     # Only on push to master (never on PR / workflow_dispatch). The
     # release-with-commit step below is itself a no-op unless the head commit
-    # message matches "Release X.Y.Z", so ordinary master pushes build wheels but
+    # message matches ":bookmark: Release X.Y.Z", so ordinary master pushes build wheels but
     # publish nothing.
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
@@ -122,11 +122,11 @@ jobs:
           persist-credentials: false
       # Creates the GitHub Release + tag only when the head commit message
       # matches the regexp; otherwise it is a no-op and 'created' is 'false'.
-      - name: Create GitHub Release on "Release X.Y.Z" commit
+      - name: 'Create GitHub Release on ":bookmark: Release X.Y.Z" commit'
         id: create_release
         uses: ChanTsune/release-with-commit@5a427bc9fbc54bf678e4c0bf36f4914d138d6b15 # v4.0.0
         with:
-          regexp: "Release (\\d+([.]\\d+)*)\n*((\\s|\\S)+)"
+          regexp: "^:bookmark: Release (\\d+([.]\\d+)*)\n*((\\s|\\S)*)"
           regexp_options: "us"
           release_name: "version $1"
           tag_name: "$1"


### PR DESCRIPTION
Align the release commit with the project gitmoji convention: the release-with-commit regexp now matches ":bookmark: Release X.Y.Z" at the message start. Anchoring prevents a ":bookmark: Release" mention in a body from triggering a release, and the trailing group is relaxed to "*" so a bodyless version keeps the full number in the tag.