### PR TITLE
🏷️ Type stats() return as a TypedDict

### DIFF
--- a/list_reserve/__init__.pyi
+++ b/list_reserve/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, TypedDict
 
 def reserve(list: list[Any], capacity: int) -> None:
     """Reserve list capacity."""
@@ -12,5 +12,12 @@ def allocated_bytes(list: list[Any]) -> int:
 def shrink_to_fit(list: list[Any]) -> None:
     """Shrink to fit list capacity."""
 
-def stats(list: list[Any]) -> dict[str, Any]:
+class Stats(TypedDict):
+    length: int
+    capacity: int
+    allocated_bytes: int
+    overhead: int
+    utilization: float
+
+def stats(list: list[Any]) -> Stats:
     """Return list memory statistics as a dict."""


### PR DESCRIPTION
stats() returns a fixed-key dict; type it as a TypedDict (Stats) so callers get precise key types (utilization: float, the rest int) instead of Any. Stub-only and 3.10-compatible; exposing Stats as a runtime export would require packaging list_reserve (separate change).