### PR TITLE
👷 Type-check the test suite with mypy in CI

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,46 @@
+name: typecheck
+
+on:
+  push:
+    paths:
+      - "**.py"
+      - "**.pyi"
+      - "src/**"
+      - "pyproject.toml"
+      - ".github/workflows/typecheck.yml"
+  # No path filter on pull_request (matching lint.yml): an unconditional run avoids
+  # a path-filtered job hanging a required status check under branch protection.
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: typecheck-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  mypy:
+    name: mypy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.x"
+      # Pin mypy (like ruff/clang-format in lint.yml) for reproducible results.
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install . mypy==2.1.0
+      - name: mypy
+        run: mypy tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,12 @@ line-length = 88
 # UP: pyupgrade (py310 baseline), RUF: Ruff-specific. Not "ALL" by design.
 select = ["E", "F", "I", "B", "UP", "RUF"]
 
+[tool.mypy]
+# check_untyped_defs makes mypy inspect the untyped test-method bodies it skips by
+# default; without it `mypy tests` would be a no-op.
+python_version = "3.10"
+check_untyped_defs = true
+
 [tool.cibuildwheel]
 # CPython only, 3.10 through 3.14. PyPy (pp*), GraalPy (gp*), free-threaded
 # (cp3??t-*) and any future minor are excluded by not matching this list.

--- a/tests/test_allocated_bytes.py
+++ b/tests/test_allocated_bytes.py
@@ -7,7 +7,7 @@ class AllocatedBytesTest(TestCase):
     def test_allocated_bytes(self):
         from list_reserve import allocated_bytes, capacity
 
-        empty = []
+        empty: list[int] = []
         one_item = [1]
 
         self.assertEqual(allocated_bytes(empty), capacity(empty) * POINTER_SIZE)
@@ -17,4 +17,4 @@ class AllocatedBytesTest(TestCase):
         from list_reserve import allocated_bytes
 
         with self.assertRaises(TypeError):
-            allocated_bytes(1)
+            allocated_bytes(1)  # type: ignore[arg-type]

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -12,4 +12,4 @@ class CapacityTest(TestCase):
         from list_reserve import capacity
 
         with self.assertRaises(TypeError):
-            capacity(1)
+            capacity(1)  # type: ignore[arg-type]

--- a/tests/test_reserve.py
+++ b/tests/test_reserve.py
@@ -33,7 +33,7 @@ class ReserveTest(TestCase):
         from list_reserve import reserve
 
         with self.assertRaises(TypeError):
-            reserve(1, 100)
+            reserve(1, 100)  # type: ignore[arg-type]
 
 
 class CapacityInvariantRegressionTest(TestCase):

--- a/tests/test_shrink_to_fit.py
+++ b/tests/test_shrink_to_fit.py
@@ -30,4 +30,4 @@ class ShrinkToFitTest(TestCase):
         from list_reserve import shrink_to_fit
 
         with self.assertRaises(TypeError):
-            shrink_to_fit(1)
+            shrink_to_fit(1)  # type: ignore[arg-type]

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -49,7 +49,7 @@ class StatsTest(TestCase):
     def test_stats_after_reserve(self):
         from list_reserve import reserve, stats
 
-        lst = []
+        lst: list[int] = []
         reserve(lst, 100)
         s = stats(lst)
         self.assertEqual(s["length"], 0)
@@ -83,4 +83,4 @@ class StatsTest(TestCase):
         from list_reserve import stats
 
         with self.assertRaises(TypeError):
-            stats(1)
+            stats(1)  # type: ignore[arg-type]


### PR DESCRIPTION
Add a typecheck workflow running `mypy tests` (pinned mypy==2.1.0) with a [tool.mypy] config; check_untyped_defs makes mypy inspect the untyped test-method bodies it skips by default, so the test suite (the public API's real consumers) is actually type-checked against the stub. Annotate two empty-list locals and mark the intentional wrong-type calls in the *_error tests with `# type: ignore[arg-type]`.