### PR TITLE
♻️ Rename stats() "overhead" key to "remaining_capacity"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pre-built binary wheels on PyPI for Linux riscv64 (manylinux + musllinux).
 - `remaining_capacity()` — return the number of additional list items that can
   be added without expanding the list.
-- `stats()` — return list memory statistics (`length`, `capacity`,
-  `allocated_bytes`, `overhead`, `utilization`) as a dict in one call.
+- `stats()` — return list memory statistics as a dict in one call.
 
 ### Removed
 - Python 3.8 and 3.9 support (end of life).

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ reserve(l, 10)
 
 print(stats(l))
 # {'length': 0, 'capacity': 10, 'allocated_bytes': 80,
-#  'overhead': 10, 'utilization': 0.0}
+#  'remaining_capacity': 10, 'utilization': 0.0}
 ```
 
 ## Development

--- a/list_reserve/__init__.pyi
+++ b/list_reserve/__init__.pyi
@@ -19,7 +19,7 @@ class Stats(TypedDict):
     length: int
     capacity: int
     allocated_bytes: int
-    overhead: int
+    remaining_capacity: int
     utilization: float
 
 def stats(list: list[Any]) -> Stats:

--- a/src/list_reserve.c
+++ b/src/list_reserve.c
@@ -152,7 +152,7 @@ list_stats(PyObject *self, PyObject *args) {
     Py_ssize_t length = PyList_GET_SIZE(list);
     Py_ssize_t allocated = list->allocated;
     Py_ssize_t allocated_bytes = allocated * sizeof(PyObject *);
-    Py_ssize_t overhead = allocated - length;
+    Py_ssize_t remaining = allocated - length;
     // capacity == 0 would divide by zero; report 0.0 utilization instead.
     double utilization = allocated == 0 ? 0.0 : (double)length / (double)allocated;
 
@@ -163,11 +163,11 @@ list_stats(PyObject *self, PyObject *args) {
 
     PyObject *values[5] = {
         PyLong_FromSsize_t(length),          PyLong_FromSsize_t(allocated),
-        PyLong_FromSsize_t(allocated_bytes), PyLong_FromSsize_t(overhead),
+        PyLong_FromSsize_t(allocated_bytes), PyLong_FromSsize_t(remaining),
         PyFloat_FromDouble(utilization),
     };
     const char *keys[5] = {
-        "length", "capacity", "allocated_bytes", "overhead", "utilization",
+        "length", "capacity", "allocated_bytes", "remaining_capacity", "utilization",
     };
     for (int i = 0; i < 5; i++) {
         if (values[i] == NULL) {

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -11,7 +11,7 @@ class StatsTest(TestCase):
         self.assertEqual(s["length"], 0)
         self.assertEqual(s["capacity"], 0)
         self.assertEqual(s["allocated_bytes"], 0)
-        self.assertEqual(s["overhead"], 0)
+        self.assertEqual(s["remaining_capacity"], 0)
         self.assertEqual(s["utilization"], 0.0)
 
     def test_stats_full(self):
@@ -24,7 +24,7 @@ class StatsTest(TestCase):
         self.assertEqual(s["length"], 3)
         self.assertEqual(s["capacity"], 3)
         self.assertEqual(s["allocated_bytes"], 3 * POINTER_SIZE)
-        self.assertEqual(s["overhead"], 0)
+        self.assertEqual(s["remaining_capacity"], 0)
         self.assertEqual(s["utilization"], 1.0)
 
     def test_stats_keys(self):
@@ -33,7 +33,13 @@ class StatsTest(TestCase):
         s = stats([])
         self.assertEqual(
             set(s.keys()),
-            {"length", "capacity", "allocated_bytes", "overhead", "utilization"},
+            {
+                "length",
+                "capacity",
+                "allocated_bytes",
+                "remaining_capacity",
+                "utilization",
+            },
         )
 
     def test_stats_value_types(self):
@@ -43,7 +49,7 @@ class StatsTest(TestCase):
         self.assertIsInstance(s["length"], int)
         self.assertIsInstance(s["capacity"], int)
         self.assertIsInstance(s["allocated_bytes"], int)
-        self.assertIsInstance(s["overhead"], int)
+        self.assertIsInstance(s["remaining_capacity"], int)
         self.assertIsInstance(s["utilization"], float)
 
     def test_stats_after_reserve(self):
@@ -54,10 +60,10 @@ class StatsTest(TestCase):
         s = stats(lst)
         self.assertEqual(s["length"], 0)
         self.assertEqual(s["capacity"], 100)
-        self.assertEqual(s["overhead"], 100)
+        self.assertEqual(s["remaining_capacity"], 100)
         self.assertEqual(s["utilization"], 0.0)
 
-    def test_stats_overhead_and_utilization(self):
+    def test_stats_remaining_capacity_and_utilization(self):
         from list_reserve import reserve, stats
 
         lst = [1, 2, 3, 4]
@@ -65,8 +71,8 @@ class StatsTest(TestCase):
         s = stats(lst)
         self.assertEqual(s["length"], 4)
         self.assertEqual(s["capacity"], 10)
-        self.assertEqual(s["overhead"], 6)
-        self.assertGreater(s["overhead"], 0)
+        self.assertEqual(s["remaining_capacity"], 6)
+        self.assertGreater(s["remaining_capacity"], 0)
         self.assertEqual(s["utilization"], 0.4)
         self.assertLess(s["utilization"], 1.0)
 


### PR DESCRIPTION
stats() reported capacity - length under the key "overhead", which is the exact value returned by remaining_capacity(). Use the same name so the dict mirrors the function (stats(lst)["remaining_capacity"] == remaining_capacity(lst)) and drop the misleading "overhead" (it is unused reserved slots, not memory overhead). stats() is unreleased, so no compatibility break.