### PR TITLE
📝 Expand docstrings with behavioural constraints

### DIFF
--- a/list_reserve/__init__.pyi
+++ b/list_reserve/__init__.pyi
@@ -1,19 +1,39 @@
 from typing import Any, TypedDict
 
 def reserve(list: list[Any], capacity: int) -> None:
-    """Reserve list capacity."""
+    """Reserve list capacity.
+
+    Grow the backing storage to hold at least capacity elements. Only ever
+    grows: a no-op when capacity already meets or exceeds the request.
+    """
 
 def capacity(list: list[Any]) -> int:
-    """Return list capacity."""
+    """Return list capacity.
+
+    The number of elements the backing storage can hold before it must grow;
+    always greater than or equal to len(list).
+    """
 
 def remaining_capacity(list: list[Any]) -> int:
-    """Return list remaining capacity."""
+    """Return list remaining capacity.
+
+    Equals capacity(list) - len(list): how many elements can be appended
+    before the backing storage must grow.
+    """
 
 def allocated_bytes(list: list[Any]) -> int:
-    """Return list allocated memory size."""
+    """Return list allocated memory size.
+
+    The size in bytes of the backing item array (capacity times the pointer
+    size); excludes the list object header.
+    """
 
 def shrink_to_fit(list: list[Any]) -> None:
-    """Shrink to fit list capacity."""
+    """Shrink to fit list capacity.
+
+    Reallocate the backing storage down to the live element count, so that
+    capacity(list) equals len(list) afterwards.
+    """
 
 class Stats(TypedDict):
     length: int
@@ -23,4 +43,8 @@ class Stats(TypedDict):
     utilization: float
 
 def stats(list: list[Any]) -> Stats:
-    """Return list memory statistics as a dict."""
+    """Return list memory statistics as a dict.
+
+    Utilization is length / capacity (0.0 when capacity is 0); the other keys
+    match the same-named functions.
+    """

--- a/src/list_reserve.c
+++ b/src/list_reserve.c
@@ -192,15 +192,46 @@ list_stats(PyObject *self, PyObject *args) {
     return dict;
 }
 
+PyDoc_STRVAR(reserve_doc,
+             "Reserve list capacity.\n"
+             "\n"
+             "Grow the backing storage to hold at least capacity elements. Only\n"
+             "ever grows: a no-op when capacity already meets or exceeds the\n"
+             "request.");
+PyDoc_STRVAR(capacity_doc,
+             "Return list capacity.\n"
+             "\n"
+             "The number of elements the backing storage can hold before it\n"
+             "must grow; always greater than or equal to len(list).");
+PyDoc_STRVAR(remaining_capacity_doc,
+             "Return list remaining capacity.\n"
+             "\n"
+             "Equals capacity(list) - len(list): how many elements can be\n"
+             "appended before the backing storage must grow.");
+PyDoc_STRVAR(allocated_bytes_doc,
+             "Return list allocated memory size.\n"
+             "\n"
+             "The size in bytes of the backing item array (capacity times the\n"
+             "pointer size); excludes the list object header.");
+PyDoc_STRVAR(shrink_to_fit_doc,
+             "Shrink to fit list capacity.\n"
+             "\n"
+             "Reallocate the backing storage down to the live element count,\n"
+             "so that capacity(list) equals len(list) afterwards.");
+PyDoc_STRVAR(stats_doc,
+             "Return list memory statistics as a dict.\n"
+             "\n"
+             "Utilization is length / capacity (0.0 when capacity is 0); the\n"
+             "other keys match the same-named functions.");
+
 static PyMethodDef methods[] = {
-    {"reserve", list_reserve, METH_VARARGS, "Reserve list capacity."},
-    {"capacity", list_capacity, METH_VARARGS, "Return list capacity."},
+    {"reserve", list_reserve, METH_VARARGS, reserve_doc},
+    {"capacity", list_capacity, METH_VARARGS, capacity_doc},
     {"remaining_capacity", list_remaining_capacity, METH_VARARGS,
-     "Return list remaining capacity."},
-    {"allocated_bytes", list_allocated_bytes, METH_VARARGS,
-     "Return list allocated memory size."},
-    {"shrink_to_fit", list_shrink_to_fit, METH_VARARGS, "Shrink to fit list capacity."},
-    {"stats", list_stats, METH_VARARGS, "Return list memory statistics as a dict."},
+     remaining_capacity_doc},
+    {"allocated_bytes", list_allocated_bytes, METH_VARARGS, allocated_bytes_doc},
+    {"shrink_to_fit", list_shrink_to_fit, METH_VARARGS, shrink_to_fit_doc},
+    {"stats", list_stats, METH_VARARGS, stats_doc},
     {NULL}};
 
 // module definition struct


### PR DESCRIPTION
Extend each public function's docstring from a one-line summary to the stdlib "summary line, blank line, body" form, documenting the constraints behind each primitive (reserve grows only, shrink_to_fit reallocs to the live element count, remaining_capacity == capacity - len, utilization handling of empty lists, etc.).

Define the C-side strings via PyDoc_STRVAR so help()/__doc__ carry the same text the type stub exposes, keeping list_reserve.c and __init__.pyi in sync.