### PR TITLE
:bookmark: Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-29
+
 ### Added
 - Pre-built binary wheels on PyPI for Linux riscv64 (manylinux + musllinux).
 - `remaining_capacity()` — return the number of additional list items that can
@@ -74,7 +76,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First release: `reserve()` and `capacity()`.
 
-[Unreleased]: https://github.com/ChanTsune/list-reserve/compare/0.4.0...HEAD
+[Unreleased]: https://github.com/ChanTsune/list-reserve/compare/0.5.0...HEAD
+[0.5.0]: https://github.com/ChanTsune/list-reserve/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/ChanTsune/list-reserve/compare/0.3.2...0.4.0
 [0.3.2]: https://github.com/ChanTsune/list-reserve/compare/0.3.1...0.3.2
 [0.3.1]: https://github.com/ChanTsune/list-reserve/compare/0.3.0...0.3.1

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ print(allocated_bytes(l)) # capacity(l) * pointer size
 
 ### remaining_capacity
 
+*since 0.5.0*  
 Return the number of additional items a list can accept before it needs to
 expand.
 
@@ -93,6 +94,7 @@ print(capacity(l)) # 100
 
 ### stats
 
+*since 0.5.0*  
 Return list memory statistics in one call.
 
 ```py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "list_reserve"
-version = "0.4.0"
+version = "0.5.0"
 description = "Python builtin list memory allocation library"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
### Added
- Pre-built binary wheels on PyPI for Linux riscv64 (manylinux + musllinux).
- `remaining_capacity()` — return the number of additional list items that can be added without expanding the list.
- `stats()` — return list memory statistics as a dict in one call.

### Removed
- Python 3.8 and 3.9 support (end of life).

### Fixed
- `reserve()` raises `MemoryError` when the requested capacity is too large to allocate.